### PR TITLE
Fix panic on dbus signal channel close

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -279,7 +279,11 @@ func New(conn *dbus.Conn, opts ...option) (Notifier, error) {
 func (n notifier) eventLoop(done <-chan struct{}) {
 	for {
 		select {
-		case signal := <-n.signal:
+		case signal, ok := <-n.signal:
+			if !ok {
+				n.log.Printf("Signal channel closed, shutting down...")
+				return
+			}
 			n.handleSignal(signal)
 		case <-done:
 			n.log.Printf("Got Close() signal, shutting down...")


### PR DESCRIPTION
The dbus signal channel that is added in notification.go:271 and is used in notification.go:282 can be closed by dbus' internal signal handler at github.com/godbus/dbus/v5@v5.0.3/default_handler.go:266.

This causes Go to panic with the following stack trace:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x544911]
    goroutine 7 [running]:
    github.com/esiqveland/notify.notifier.handleSignal({0xc00019e000, 0xc000288180, 0xc0002a2060, 0xc00028e0b0, 0x5d3680, 0xc00028a0d0, {0x601080, 0xc000132000}}, 0x0)
            github.com/esiqveland/notify@v0.11.0/notification.go:274 +0x51
    github.com/esiqveland/notify.notifier.eventLoop({0xc00019e000, 0xc000288180, 0xc0002a2060, 0xc00028e0b0, 0x5d3680, 0xc00028a0d0, {0x601080, 0xc000132000}})
            github.com/esiqveland/notify@v0.11.0/notification.go:264 +0x109
    created by github.com/esiqveland/notify.New
            github.com/esiqveland/notify@v0.11.0/notification.go:253 +0x391

This commit handles this case and returns appropriately so no panic occurs.